### PR TITLE
Readability, phpDocBlocks, php5, file security, i18n

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -1,7 +1,4 @@
 <?php
-# -*- coding: utf-8 -*-
-declare ( encoding = 'UTF-8' );
-
 // Prevent loading this file directly - Busted!
 if ( ! class_exists('WP') ) 
 {
@@ -62,15 +59,15 @@ class wp_github_updater {
 		$name	= 'jkudish';
 		$repo	= 'WordPress-GitHub-Plugin-Updater';
 		$defaults = array(
-			'slug'				=> plugin_basename( __FILE__ ),
-			'proper_folder_name'=> plugin_basename( __FILE__ ),
-			'api_url'			=> "{$http}api.{$host}/repos/{$name}/{$repo}",
-			'raw_url'			=> "{$http}raw.{$host}/{$name}/{$repo}/master",
-			'github_url'		=> "{$http}{$host}/{$name}/{$repo}",
-			'zip_url'			=> "{$http}{$host}/{$name}/{$repo}/zipball/master",
-			'sslverify'			=> true,
-	    	'requires'			=> $wp_version,
-        	'tested'			=> $wp_version,
+			'slug'               => plugin_basename( __FILE__ ),
+			'proper_folder_name' => plugin_basename( __FILE__ ),
+			'api_url'            => "{$http}api.{$host}/repos/{$name}/{$repo}",
+			'raw_url'            => "{$http}raw.{$host}/{$name}/{$repo}/master",
+			'github_url'         => "{$http}{$host}/{$name}/{$repo}",
+			'zip_url'            => "{$http}{$host}/{$name}/{$repo}/zipball/master",
+			'sslverify'          => true,
+	    	'requires'           => $wp_version,
+        	'tested'             => $wp_version
 		);	
 
 		$this->config = wp_parse_args( $config, $defaults );
@@ -267,10 +264,10 @@ class wp_github_updater {
 		$update = version_compare( $this->config['new_version'], $this->config['version'] );
 		if ( 1 === $update ) {		
 			$response = new stdClass;
-			$response->new_version	= $this->config['new_version'];
-			$response->slug			= $this->config['slug'];		
-			$response->url			= $this->config['github_url'];
-			$response->package		= $this->config['zip_url'];
+			$response->new_version = $this->config['new_version'];
+			$response->slug        = $this->config['slug'];		
+			$response->url         = $this->config['github_url'];
+			$response->package     = $this->config['zip_url'];
 
 			// If response is false, don't alter the transient
 			if ( false !== $response )
@@ -298,16 +295,16 @@ class wp_github_updater {
 		if ( $args->slug != $this->config['slug'] )
 			return false;
 
-	    $response->slug			= $this->config['slug'];
-	    $response->plugin_name	= $this->config['plugin_name'];
-	    $response->version		= $this->config['new_version'];
-	    $response->author		= $this->config['author'];
-	    $response->homepage		= $this->config['homepage'];
-	    $response->requires		= $this->config['requires'];
-	    $response->tested		= $this->config['tested'];
-	    $response->downloaded	= 0;
-	    $response->last_updated	= $this->config['last_updated'];
-	    $response->sections		= array(
+	    $response->slug          = $this->config['slug'];
+	    $response->plugin_name   = $this->config['plugin_name'];
+	    $response->version       = $this->config['new_version'];
+	    $response->author        = $this->config['author'];
+	    $response->homepage      = $this->config['homepage'];
+	    $response->requires      = $this->config['requires'];
+	    $response->tested        = $this->config['tested'];
+	    $response->downloaded    = 0;
+	    $response->last_updated  = $this->config['last_updated'];
+	    $response->sections      = array(
 	        'description' => $this->config['description']
 	    );        
 	    $response->download_link = $this->config['zip_url'];


### PR DESCRIPTION
- Moved from <code>$var = $some.'-'.$string;</code> to <code>$var = "{$some}-{$string}";</code> for better code readability (and GitHub parses it much nicer).
- declare UTF-8 on top
- Deny direct file access
- Added Text Domain and moved to translatable update message strings
- Moved from <code>array( &$this, 'cb_fn_name' );</code> to <code>$this</code> as the `&` is not needed with php5.
- Added phpDocBlock comments for IDEs
- minor stuff
