### PR TITLE
Detect and configure Git updates from plugin headers only

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,19 @@ The code is still in it's infancy, but [I am currently using it](https://github.
 Usage instructions
 ===========
 
-* The class should be included somewhere in your plugin. You will need to require the file (example: `include_once('updater.php');`).
-* You will need to initialize the class using something similar to this:
+* The plugin can be either be activated in WordPress, or updater.php can be included in your own plugin using `include_once 'updater.php';`.
+* Either way, the plugin will activate Github updates for every plugin with a github.com repository as the Plugin URI in its header:
 
 	<pre>
-	if (is_admin()) { // note the use of is_admin() to double check that this is happening in the admin
-		$config = array(
-			'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
-			'proper_folder_name' => 'plugin-name', // this is the name of the folder your plugin lives in
-			'api_url' => 'https://api.github.com/repos/username/repository-name', // the github API url of your github repo
-			'raw_url' => 'https://raw.github.com/username/repository-name/master', // the github raw url of your github repo
-			'github_url' => 'https://github.com/username/repository-name', // the github url of your github repo
-			'zip_url' => 'https://github.com/username/repository-name/zipball/master', // the zip url of the github repo
-			'sslverify' => true // wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
-			'requires' => '3.0', // which version of WordPress does your plugin require?
-			'tested' => '3.3', // which version of WordPress is your plugin tested up to?
-			'readme' => 'README.MD' // which file to use as the readme for the version number
-		);
-		new WPGitHubUpdater($config);
-	}
+	/*
+	Plugin Name: Plugin Example
+	Plugin URI: https://github.com/jkudish/WordPress-GitHub-Plugin-Updater
+	Requires: 3.0
+	Tested: 3.4
+	*/
 	</pre>
 
-* In your Github repository, you will need to include the following line (formatted exactly like this) anywhere in your Readme file:
-
-	`~Current Version:1.4~`
-
-* You will need to update the version number anytime you update the plugin, this will ultimately let the plugin know that a new version is available.
+* In your Github repository, you will need to tag releases with new version numbers. New commits will not trigger an update until they are tagged with a higher version number. Don't forget to push your tags: `git push origin --tags`
 
 * **Note**: this class will unfortunately not work with a private repository, your repository needs to be publicly accessible. If anyone knows how to make this work for private repositories, please get in touch!
 

--- a/plugin.php
+++ b/plugin.php
@@ -1,9 +1,8 @@
 <?php
-
 /*
-Plugin Name: WP Github Plugin Updater Test
+Plugin Name: WP Github Plugin Updater
 Plugin URI: https://github.com/jkudish/WordPress-GitHub-Plugin-Updater
-Description: Semi-automated test for the Github Plugin Updater
+Description: Enable updates for all plugins with github.com in the header under Plugin URI.
 Version: 0.1
 Author: Joachim Kudish
 Author URI: http://jkudish.com/
@@ -13,53 +12,15 @@ License: GPLv2
 /**
  * Note: the version # above is purposely low in order to be able to test the updater
  * The real version # is below
+ *
  * @package GithubUpdater
  * @author Joachim Kudish @link http://jkudish.com
  * @since 1.3
- * @version 1.3
-*/
-
-/*
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+ * @version 1.4
+ * @author Joachim Kudish <info@jkudish.com>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
+ * @copyright Copyright (c) 2011, Joachim Kudish
+ */
 
 
-add_action('init', 'github_plugin_updater_test_init');
-function github_plugin_updater_test_init() {
-
-	include_once('updater.php');
-
-	define('WP_GITHUB_FORCE_UPDATE', true);
-
-	if (is_admin()) { // note the use of is_admin() to double check that this is happening in the admin
-
-		$config = array(
-			'slug' => plugin_basename(__FILE__),
-			'proper_folder_name' => 'github-updater',
-			'api_url' => 'https://api.github.com/repos/jkudish/WordPress-GitHub-Plugin-Updater',
-			'raw_url' => 'https://raw.github.com/jkudish/WordPress-GitHub-Plugin-Updater/master',
-			'github_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater',
-			'zip_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/zipball/master',
-			'sslverify' => true,
-			'requires' => '3.0',
-			'tested' => '3.3',
-			'readme' => 'readme.txt'
-		);
-
-		new WPGitHubUpdater($config);
-
-	}
-
-}
+include_once dirname(__FILE__).'/updater.php';

--- a/updater.php
+++ b/updater.php
@@ -1,37 +1,36 @@
 <?php
-
-// Prevent loading this file directly - Busted!
-if ( !defined('ABSPATH') )
-	die('-1');
-
-if ( ! class_exists( 'WPGitHubUpdater' ) ) :
-
 /**
+ * @package GithubUpdater
+ * @author Joachim Kudish @link http://jkudish.com
+ * @since 1.3
  * @version 1.4
  * @author Joachim Kudish <info@jkudish.com>
- * @link http://jkudish.com
- * @package GithubUpdater
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
  * @copyright Copyright (c) 2011, Joachim Kudish
- *
- * GNU General Public License, Free Software Foundation
- * <http://creativecommons.org/licenses/GPL/2.0/>
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
+
+if ( !class_exists('WPGitHubUpdater') ) :
+
+add_action('admin_init', create_function('', 'global $WPGitHubUpdater; $WPGitHubUpdater = new WPGitHubUpdater();') );
+
 class WPGitHubUpdater {
+
+	/**
+	 *	Whether to verify SSL for Git-related connections
+	 * Override with <code> add_filter('git_sslverify', create_function('', 'return false;') ); </code>
+	 */
+	var $ssl_verify = true;
+
+	/**
+	 *	List of URLs related to Git repositories.
+	 * Used by disable_git_ssl() method
+	 */
+	var $git_urls = array();
+
+	/**
+	 * Installed plugins that list Github as the Plugin URI. Includes metadata.
+	 */
+	var $plugins = array();
 
 	/**
 	 * Class Constructor
@@ -42,70 +41,88 @@ class WPGitHubUpdater {
 	 */
 	public function __construct( $config = array() ) {
 
-		global $wp_version;
-
-		$defaults = array(
-			'slug' => plugin_basename(__FILE__),
-			'proper_folder_name' => dirname( plugin_basename(__FILE__) ),
-			'api_url' => 'https://api.github.com/repos/jkudish/WordPress-GitHub-Plugin-Updater',
-			'raw_url' => 'https://raw.github.com/jkudish/WordPress-GitHub-Plugin-Updater/master',
-			'github_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater',
-			'zip_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/zipball/master',
-			'sslverify' => true,
-			'requires' => $wp_version,
-			'tested' => $wp_version
-		);
-
-		$this->config = wp_parse_args( $config, $defaults );
-
-		$this->set_defaults();
+		$this->ssl_verify = apply_filters('git_sslverify', $this->ssl_verify);
 
 		if ( ( defined('WP_DEBUG') && WP_DEBUG ) || ( defined('WP_GITHUB_FORCE_UPDATE') || WP_GITHUB_FORCE_UPDATE ) )
-			add_action( 'init', array( $this, 'delete_transients' ) );
+			add_action( 'init', array( $this, 'delete_transients' ), 11 );
 
+		// Build Git plugin list
+		add_action( 'admin_init', array($this, 'load_plugins'), 0 );
+		add_filter( 'extra_plugin_headers', array($this, 'extra_plugin_headers') );
+
+		// Check for update from Git API
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ) );
 
-		// Hook into the plugin details screen
+		// Plugin details screen
 		add_filter( 'plugins_api', array( $this, 'get_plugin_info' ), 10, 3 );
+
+		// Cleanup and activate plugins after update
 		add_filter( 'upgrader_post_install', array( $this, 'upgrader_post_install' ), 10, 3 );
 
-		// set timeout
+		// HTTP Timeout
 		add_filter( 'http_request_timeout', array( $this, 'http_request_timeout' ) );
+
+		// Maybe disable HTTP SSL Certificate Check for Git URLs
+		// If statement can likely be removed.
+		// @see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2#issuecomment-6654644
+		if ( false === $this->ssl_verify ) {
+			add_filter( 'http_request_args', array($this, 'disable_git_ssl_verify'), 10, 2 );
+		}
 	}
 
 
 	/**
-	 * Set defaults
+	 *	Build $this->plugins, a list of Github-hosted plugins based on installed plugin headers
 	 *
-	 * @since 1.2
 	 * @return void
 	 */
-	public function set_defaults() {
+	public function load_plugins( $plugins ) {
+		$this->plugins = get_site_transient( 'git_plugins' );
 
-		if ( ! isset( $this->config['new_version'] ) )
-			$this->config['new_version'] = $this->get_new_version();
+		if ( false !== $this->plugins ) {
+			return;
+		}
 
-		if ( ! isset( $this->config['last_updated'] ) )
-			$this->config['last_updated'] = $this->get_date();
+		global $wp_version;
 
-		if ( ! isset( $this->config['description'] ) )
-			$this->config['description'] = $this->get_description();
+		foreach ( get_plugins() as $slug => $meta ) {
+			$repo = $this->get_repo_parts( $meta['PluginURI'] );
 
-		$plugin_data = $this->get_plugin_data();
-		if ( ! isset( $this->config['plugin_name'] ) )
-			$this->config['plugin_name'] = $plugin_data['Name'];
+			if (false === $repo ) {
+				continue;
+			}
 
-		if ( ! isset( $this->config['version'] ) )
-			$this->config['version'] = $plugin_data['Version'];
+			$key = dirname($slug);
 
-		if ( ! isset( $this->config['author'] ) )
-			$this->config['author'] = $plugin_data['Author'];
+			$settings = array(
+				'name' => $meta['Name'],
+				'slug' => $slug,
+				'folder_name' => $key,
+				'host'  => $repo['host'],
+				'username' => $repo['username'],
+				'repository' => $repo['repository'],
+				'version' => $meta['Version'],
+				'author' => $meta['Author'],
+				'homepage' => $meta['PluginURI'],
+				'api_url' =>  "https://api.github.com/repos/{$repo['username']}/{$repo['repository']}",
+				'tags_url' => "https://api.github.com/repos/{$repo['username']}/{$repo['repository']}/tags",
+			);
 
-		if ( ! isset( $this->config['homepage'] ) )
-			$this->config['homepage'] = $plugin_data['PluginURI'];
+			$settings['requires'] = (empty($meta['requires'])) ? $wp_version : $meta['requires'];
+			$settings['tested']   = (empty($meta['tested'])) ? $wp_version : $meta['tested'];
 
-		if ( ! isset( $this->config['readme'] ) )
-			$this->config['readme'] = 'README.md';
+			// Using folder name as key for array_key_exists() check in $this->get_plugin_info()
+			$this->plugins[$key] = wp_parse_args( $settings, $this->defaults );
+
+			$this->set_new_version_and_zip_url( $key );
+			$this->set_last_updated( $key );
+			$this->set_description( $key );
+
+		}
+
+		// Refresh plugin list and Git metadata every 6 hours
+		set_site_transient( 'git_plugins', $this->plugins, 60*60*6 );
+
 	}
 
 
@@ -121,6 +138,42 @@ class WPGitHubUpdater {
 
 
 	/**
+	 * Additional headers
+	 *
+	 * @return array plugin header search terms
+	 */
+	public function extra_plugin_headers() {
+		return array( 'requires', 'tested' );
+	}
+
+
+	/**
+	 * Disable SSL only for git repo URLs, but no other HTTP requests
+	 *	Allows SSL to be disabled for zip are downloadeds outside plugin scope
+	 *
+	 * @return array $args http_request_args
+	 */
+	public function disable_git_ssl_verify($args, $url) {
+		if ( empty($this->plugins)) {
+			return;
+		}
+		if ( empty($this->git_urls) ) {
+			foreach( $this->plugins as $plugin ) {
+				$this->git_urls[] = $plugin['homepage'];
+				$this->git_urls[] = $plugin['api_url'];
+				$this->git_urls[] = $plugin['tags_url'];
+				$this->git_urls[] = $plugin['zip_url'];
+			}
+		} 
+		if ( in_array($url, $this->git_urls) ) {
+			$args['sslverify'] = false; 
+		}
+
+		return $args;
+	}
+
+
+	/**
 	 * Delete transients (runs when WP_DEBUG is on)
 	 * For testing purposes the site transient will be reset on each page load
 	 *
@@ -129,9 +182,7 @@ class WPGitHubUpdater {
 	 */
 	public function delete_transients() {
 		delete_site_transient( 'update_plugins' );
-		delete_site_transient( $this->config['slug'].'_new_version' );
-		delete_site_transient( $this->config['slug'].'_github_data' );
-		delete_site_transient( $this->config['slug'].'_changelog' );
+		delete_site_transient( 'git_plugins' );
 	}
 
 
@@ -139,36 +190,51 @@ class WPGitHubUpdater {
 	 * Get New Version from github
 	 *
 	 * @since 1.0
-	 * @return int $version the version number
+	 * @return void
 	 */
-	public function get_new_version() {
-		$version = get_site_transient( $this->config['slug'].'_new_version' );
+	public function set_new_version_and_zip_url( $key ) {
+		$plugin = $this->plugins[$key];
 
-		if ( !isset( $version ) || !$version || '' == $version ) {
+		$raw_response = wp_remote_get( $plugin['tags_url'] );
 
-			$raw_response = wp_remote_get(
-				trailingslashit($this->config['raw_url']).$this->config['readme'],
-				array(
-					'sslverify' => $this->config['sslverify'],
-				)
-			);
+		if ( is_wp_error( $raw_response ) )
+			return false;
 
-			if ( is_wp_error( $raw_response ) )
-				return false;
-
-			$__version	= explode( '~Current Version:', $raw_response['body'] );
-
-			if ( !isset($__version['1']) )
-				return false;
-
-			$_version	= explode( '~', $__version['1'] );
-			$version	= $_version[0];
-
-			// refresh every 6 hours
-			set_site_transient( $this->config['slug'].'_new_version', $version, 60*60*6 );
+		$tags = json_decode( $raw_response['body'] );
+			
+		$version = false;
+		$zip_url = false;
+		foreach ( $tags as $tag ) {
+			if ( version_compare($tag->name, $version, '>=') ) {
+				$version = $tag->name;
+				$zip_url = $tag->zipball_url;
+			}
 		}
 
-		return $version;
+		$this->plugins[ $key ]['new_version'] = $version;
+		$this->plugins[ $key ]['zip_url'] = $zip_url;
+
+	}
+
+	/**
+	 * Check if a URI is a github repo.
+	 * Return host, username, and repository name if so.
+	 *
+	 * @return array host, username, repository
+	 */
+	public function get_repo_parts( $uri ) {
+		$parsed = parse_url( $uri );
+		
+		if ( false !== strpos($parsed['host'], 'github.com') ) {
+			list( /*nothing*/, $username, $repository ) = explode('/', $parsed['path'] );
+			return array(
+				'host' => $parsed['host'],
+				'username' => $username,
+				'repository' => $repository,
+			);
+		}else {
+			return false;
+		}
 	}
 
 
@@ -178,22 +244,20 @@ class WPGitHubUpdater {
 	 * @since 1.0
 	 * @return array $github_data the data
 	 */
-	public function get_github_data() {
-		$github_data = get_site_transient( $this->config['slug'].'_github_data' );
+	public function get_github_data( $key ) {
+
+		$plugin = $this->plugins[$key];
+		$github_data = $plugin['github_data'];
 
 		if ( ! isset( $github_data ) || ! $github_data || '' == $github_data ) {
-			$github_data = wp_remote_get(
-				 $this->config['api_url']
-				,$this->config['sslverify']
-			);
+			$github_data = wp_remote_get( $plugin['api_url'] );
 
 			if ( is_wp_error( $github_data ) )
 				return false;
 
 			$github_data = json_decode( $github_data['body'] );
 
-			// refresh every 6 hours
-			set_site_transient( $this->config['slug'].'_github_data', $github_data, 60*60*6);
+			$this->plugins[$key]['github_data'] = $github_data;
 		}
 
 		return $github_data;
@@ -206,8 +270,8 @@ class WPGitHubUpdater {
 	 * @since 1.0
 	 * @return string $date the date
 	 */
-	public function get_date() {
-		$_date = $this->get_github_data();
+	public function set_last_updated( $key ) {
+		$_date = $this->get_github_data( $key );
 		return ( !empty($_date->updated_at) ) ? date( 'Y-m-d', strtotime( $_date->updated_at ) ) : false;
 	}
 
@@ -218,22 +282,9 @@ class WPGitHubUpdater {
 	 * @since 1.0
 	 * @return string $description the description
 	 */
-	public function get_description() {
-		$_description = $this->get_github_data();
+	public function set_description( $key ) {
+		$_description = $this->get_github_data( $key );
 		return ( !empty($_description->description) ) ? $_description->description : false;
-	}
-
-
-	/**
-	 * Get Plugin data
-	 *
-	 * @since 1.0
-	 * @return object $data the data
-	 */
-	public function get_plugin_data() {
-		include_once( ABSPATH.'/wp-admin/includes/plugin.php' );
-		$data = get_plugin_data( WP_PLUGIN_DIR.'/'.$this->config['slug'] );
-		return $data;
 	}
 
 
@@ -251,19 +302,21 @@ class WPGitHubUpdater {
 		if ( empty( $transient->checked ) )
 			return $transient;
 
-		// check the version and decide if it's new
-		$update = version_compare( $this->config['new_version'], $this->config['version'] );
+		foreach( $this->plugins as $plugin ) {
+			// check the version and decide if it's new
+			$update = version_compare( $plugin['new_version'], $plugin['version'] );
 
-		if ( 1 === $update ) {
-			$response = new stdClass;
-			$response->new_version = $this->config['new_version'];
-			$response->slug = $this->config['proper_folder_name'];
-			$response->url = $this->config['github_url'];
-			$response->package = $this->config['zip_url'];
+			if ( 1 === $update ) {
+				$response = new stdClass;
+				$response->new_version = $plugin['new_version'];
+				$response->slug = $plugin['folder_name'];
+				$response->url = $plugin['homepage'];
+				$response->package = $plugin['zip_url'];
 
-			// If response is false, don't alter the transient
-			if ( false !== $response )
-				$transient->response[ $this->config['slug'] ] = $response;
+				// If response is false, don't alter the transient
+				if ( false !== $response )
+					$transient->response[ $plugin['slug'] ] = $response;
+			}
 		}
 
 		return $transient;
@@ -280,22 +333,23 @@ class WPGitHubUpdater {
 	 * @return object $response the plugin info
 	 */
 	public function get_plugin_info( $false, $action, $response ) {
-
 		// Check if this call API is for the right plugin
-		if ( $response->slug != $this->config['slug'] )
+		if ( !array_key_exists($response->slug, $this->plugins) )
 			return false;
 
-		$response->slug = $this->config['slug'];
-		$response->plugin_name  = $this->config['plugin_name'];
-		$response->version = $this->config['new_version'];
-		$response->author = $this->config['author'];
-		$response->homepage = $this->config['homepage'];
-		$response->requires = $this->config['requires'];
-		$response->tested = $this->config['tested'];
+		$plugin = $this->plugins[ $response->slug ];
+
+		$response->slug = $plugin['slug'];
+		$response->plugin_name  = $plugin['name'];
+		$response->version = $plugin['new_version'];
+		$response->author = $plugin['author'];
+		$response->homepage = $plugin['homepage'];
+		$response->requires = $plugin['requires'];
+		$response->tested = $plugin['tested'];
 		$response->downloaded   = 0;
-		$response->last_updated = $this->config['last_updated'];
-		$response->sections = array( 'description' => $this->config['description'] );
-		$response->download_link = $this->config['zip_url'];
+		$response->last_updated = $plugin['last_updated'];
+		$response->sections = array( 'description' => $plugin['description'] );
+		$response->download_link = $plugin['zip_url'];
 
 		return $response;
 	}
@@ -315,11 +369,13 @@ class WPGitHubUpdater {
 
 		global $wp_filesystem;
 
+		$plugin = $this->plugins[ $hook_extra['plugin'] ];
+
 		// Move & Activate
-		$proper_destination = WP_PLUGIN_DIR.'/'.$this->config['proper_folder_name'];
+		$proper_destination = WP_PLUGIN_DIR.'/'.$plugin['folder_name'];
 		$wp_filesystem->move( $result['destination'], $proper_destination );
 		$result['destination'] = $proper_destination;
-		$activate = activate_plugin( WP_PLUGIN_DIR.'/'.$this->config['slug'] );
+		$activate = activate_plugin( WP_PLUGIN_DIR.'/'.$plugin['slug'] );
 
 		// Output the update message
 		$fail		= __('The plugin has been updated, but could not be reactivated. Please reactivate it manually.', 'github_plugin_updater');


### PR DESCRIPTION
This sets WPGitHubUpdater up as a self-configuring plugin that can either enabled in WordPress or included in another plugin.

Either way, the class enables Github updates for all plugins that use a github.com repository address as the Plugin URI in the header. For example:

```
/*
Plugin Name: WP Github Plugin Updater
Plugin URI: https://github.com/jkudish/WordPress-GitHub-Plugin-Updater
Requires: 2.8 (optional)
Tested: 3.4 (optional)
*/
```

The class doesn't just work for one plugin -- it searches and enabled all plugins. If searching Plugin URI would be inadvisable, an additional header item, like `Git URI` could be used instead.

To further reduce configuration, the plugin gets the latest version number and zip url from repository tags. The only required setup is a github repository URL.
