### PR TITLE
Fix 'sslverify' parameter usage

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -183,8 +183,10 @@ class WPGitHubUpdater {
 
 		if ( ! isset( $github_data ) || ! $github_data || '' == $github_data ) {
 			$github_data = wp_remote_get(
-				 $this->config['api_url']
-				,$this->config['sslverify']
+				$this->config['api_url'],
+				array(
+					'sslverify' => $this->config['sslverify'],
+				)
 			);
 
 			if ( is_wp_error( $github_data ) )


### PR DESCRIPTION
I tried setting sslverify to false, WP saw my update, but couldn't get the ZIP from GitHub. Debugged and found that this was using the parameter wrong, probably just a mistype I'm sure.
