### PR TITLE
Add filter for sslverify on zip url

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -71,6 +71,9 @@ class WPGitHubUpdater {
 
 		// set timeout
 		add_filter( 'http_request_timeout', array( $this, 'http_request_timeout' ) );
+		
+		// set sslverify for zip download
+		add_filter( 'http_request_args', array( $this, 'http_request_sslverify' ), 10, 2 );
 	}
 
 
@@ -118,6 +121,21 @@ class WPGitHubUpdater {
 	public function http_request_timeout() {
 		return 2;
 	}
+
+	/**
+	 * Callback fn for the http_request_args filter
+	 *
+	 * @param $args
+	 * @param $url
+	 *
+	 * @return mixed
+	 */
+	public function http_request_sslverify ( $args, $url ) {
+		if ( $this->config[ 'zip_url' ] == $url )
+			$args[ 'sslverify' ] = $this->config[ 'sslverify' ];
+
+		return $args;
+        }
 
 
 	/**


### PR DESCRIPTION
the zip_url never gets the sslverify setting passed from this plugin, because it's not hooked into at the point when it's run. This addition will set sslverify to the config settings when WP goes to download the ZIP. Otherwise, sslverify defaults to true and fails on certain hosts that have no idea what the GitHub SSL certificate is (lol).

Props to @pglewis for digging so deep to find this fix.
