### PR TITLE
negated the empty() check on line 117

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -114,7 +114,7 @@ class WP_GitHub_Updater {
 		);
 
 		foreach ( $required_config_params as $required_param ) {
-			if ( ! empty( $this->config[$required_param] ) )
+			if ( empty( $this->config[$required_param] ) )
 				$this->missing_config[] = $required_param;
 		}
 


### PR DESCRIPTION
On line 117 the check for empty() has an exclamation on front of it, this negates what it is suppose to do so I removed it.
