### PR TITLE
Enhanced get_new_version (depends on #35)

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -215,36 +215,30 @@ class WP_GitHub_Updater {
 	public function get_new_version() {
 		$version = get_site_transient( $this->config['slug'].'_new_version' );
 
-		if ( $this->overrule_transients() || ( !isset( $version ) || !$version || '' == $version ) ) {
+		if ( $this->overrule_transients() || empty( $version ) ) {
+			$version = null;
 
 			$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . basename( $this->config['slug'] ) );
 
-			if ( is_wp_error( $raw_response ) )
-				$version = false;
+			if ( ! is_wp_error( $raw_response ) ) {
+				preg_match( '#^\s*Version\:\s*(.*)$#im', $raw_response['body'], $matches );
 
-			preg_match( '#^\s*Version\:\s*(.*)$#im', $raw_response['body'], $matches );
-
-			if ( empty( $matches[1] ) )
-				$version = false;
-			else
-				$version = $matches[1];
+				if ( ! empty( $matches[1] ) )
+					$version = $matches[1];
+			}
 
 			// back compat for older readme version handling
 			$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . $this->config['readme'] );
 
-			if ( is_wp_error( $raw_response ) )
-				return $version;
+			if ( ! is_wp_error( $raw_response ) ) {
+				preg_match( '#^\s*`*~Current Version\:\s*([^~]*)~#im', $raw_response['body'], $__version );
 
-			preg_match( '#^\s*`*~Current Version\:\s*([^~]*)~#im', $raw_response['body'], $__version );
-
-			if ( isset( $__version[1] ) ) {
-				$version_readme = $__version[1];
-				if ( -1 == version_compare( $version, $version_readme ) )
-					$version = $version_readme;
+				if ( isset( $__version[1] ) && -1 == version_compare( $version, $__version[1] ) )
+					$version = $__version[1];
 			}
 
 			// refresh every 6 hours
-			if ( false !== $version )
+			if ( ! empty( $version ) )
 				set_site_transient( $this->config['slug'].'_new_version', $version, 60*60*6 );
 		}
 


### PR DESCRIPTION
The check for the version is now just an call to empty() as that should do?

It then assumes 'null' as its default value and tries to get a new version. Which should always work, but if it does not it returns this 'null'

Maybe for better working the fallback should return sooner or the orginal transient should be returned or the 'null' could be converted to ''

Depends on #35. Or we wait for the previous commit.
