### PR TITLE
_doing_it_wrong does not show the $message variable

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -80,7 +80,7 @@ class WP_GitHub_Updater {
 		if ( ! $this->has_minimum_config() ) {
 			$message = 'The GitHub Updater was initialized without the minimum required configuration, please check the config in your plugin. The following params are missing: ';
 			$message .= implode( ',', $this->missing_config );
-			_doing_it_wrong( __CLASS__, '' , self::VERSION );
+			_doing_it_wrong( __CLASS__, $message , self::VERSION );
 			return;
 		}
 


### PR DESCRIPTION
Now, when your minimum requirements fail you see a message which does not allow you to find out what went wrong. Replaced the '' with $message.
