### PR TITLE
Allow Slimmer config array

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ Usage instructions
 		$config = array(
 			'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
 			'proper_folder_name' => 'plugin-name', // this is the name of the folder your plugin lives in
-			'api_url' => 'https://api.github.com/repos/username/repository-name', // the github API url of your github repo
-			'raw_url' => 'https://raw.github.com/username/repository-name/master', // the github raw url of your github repo
 			'github_url' => 'https://github.com/username/repository-name', // the github url of your github repo
-			'zip_url' => 'https://github.com/username/repository-name/zipball/master', // the zip url of the github repo
-			'sslverify' => true // wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
+			'branch' => 'master', // (optional) the github branch 
+			'api_url' => 'https://api.github.com/repos/username/repository-name', // (optional) the github API url of your github repo
+        	'raw_url' => 'https://raw.github.com/username/repository-name/master', // (optional) the github raw url of your github repo
+        	'zip_url' => 'https://github.com/username/repository-name/zipball/master', // (optional) the zip url of the github repo
+			'sslverify' => true // (optional) wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
 			'requires' => '3.0', // which version of WordPress does your plugin require?
-			'tested' => '3.3', // which version of WordPress is your plugin tested up to?
+			'tested' => '3.5', // which version of WordPress is your plugin tested up to?
 			'readme' => 'README.md', // which file to use as the readme for the version number
-			'access_token' => '', // Access private repositories by authorizing under Appearance > Github Updates when this example plugin is installed
+			'access_token' => '', //(optional) Access private repositories by authorizing under Appearance > Github Updates when this example plugin is installed
 		);
 		new WPGitHubUpdater($config);
 	}

--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@ Usage instructions
 * The class should be included somewhere in your plugin. You will need to require the file (example: `include_once('updater.php');`).
 * You will need to initialize the class using something similar to this:
 
-	<pre>
-	if (is_admin()) { // note the use of is_admin() to double check that this is happening in the admin
-		$config = array(
-			'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
-			'proper_folder_name' => 'plugin-name', // this is the name of the folder your plugin lives in
-			'github_url' => 'https://github.com/username/repository-name', // the github url of your github repo
-			'branch' => 'master', // (optional) the github branch 
-			'api_url' => 'https://api.github.com/repos/username/repository-name', // (optional) the github API url of your github repo
-        	'raw_url' => 'https://raw.github.com/username/repository-name/master', // (optional) the github raw url of your github repo
-        	'zip_url' => 'https://github.com/username/repository-name/zipball/master', // (optional) the zip url of the github repo
-			'sslverify' => true // (optional) wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
-			'requires' => '3.0', // which version of WordPress does your plugin require?
-			'tested' => '3.5', // which version of WordPress is your plugin tested up to?
-			'readme' => 'README.md', // which file to use as the readme for the version number
-			'access_token' => '', //(optional) Access private repositories by authorizing under Appearance > Github Updates when this example plugin is installed
-		);
-		new WPGitHubUpdater($config);
-	}
-	</pre>
+```php
+if (is_admin()) { // note the use of is_admin() to double check that this is happening in the admin
+	$config = array(
+		'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
+		'proper_folder_name' => 'plugin-name', // this is the name of the folder your plugin lives in
+		'github_url' => 'https://github.com/username/repository-name', // the github url of your github repo
+		'branch' => 'master', // (optional) the github branch 
+		'api_url' => 'https://api.github.com/repos/username/repository-name', // (optional) the github API url of your github repo
+		'raw_url' => 'https://raw.github.com/username/repository-name/master', // (optional) the github raw url of your github repo
+		'zip_url' => 'https://github.com/username/repository-name/zipball/master', // (optional) the zip url of the github repo
+		'sslverify' => true // (optional) wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
+		'requires' => '3.0', // which version of WordPress does your plugin require?
+		'tested' => '3.5', // which version of WordPress is your plugin tested up to?
+		'readme' => 'README.md', // which file to use as the readme for the version number
+		'access_token' => '', //(optional) Access private repositories by authorizing under Appearance > Github Updates when this example plugin is installed
+	);
+	new WPGitHubUpdater($config);
+}
+```
 
 * In your Github repository, you will need to include the following line (formatted exactly like this) anywhere in your Readme file:
 

--- a/plugin.php
+++ b/plugin.php
@@ -47,10 +47,7 @@ function github_plugin_updater_test_init() {
 		$config = array(
 			'slug' => plugin_basename( __FILE__ ),
 			'proper_folder_name' => 'github-updater',
-			'api_url' => 'https://api.github.com/repos/jkudish/WordPress-GitHub-Plugin-Updater',
-			'raw_url' => 'https://raw.github.com/jkudish/WordPress-GitHub-Plugin-Updater/master',
 			'github_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater',
-			'zip_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/zipball/master',
 			'sslverify' => true,
 			'requires' => '3.0',
 			'tested' => '3.3',

--- a/plugin.php
+++ b/plugin.php
@@ -48,11 +48,9 @@ function github_plugin_updater_test_init() {
 			'slug' => plugin_basename( __FILE__ ),
 			'proper_folder_name' => 'github-updater',
 			'github_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater',
-			'sslverify' => true,
 			'requires' => '3.0',
 			'tested' => '3.3',
 			'readme' => 'README.md',
-			'access_token' => '',
 		);
 
 		new WP_GitHub_Updater( $config );

--- a/updater.php
+++ b/updater.php
@@ -72,9 +72,25 @@ class WP_GitHub_Updater {
 			'proper_folder_name' => dirname( plugin_basename( __FILE__ ) ),
 			'sslverify' => true,
 			'access_token' => '',
+			'branch' => 'master'
 		);
 
+
 		$this->config = wp_parse_args( $config, $defaults );
+
+		if (isset($this->config['github_url']) 
+			if (! array_key_exists('api_url')){
+				$this->config['api_url'] = str_replace("github.com", "api.github.com/repos", $this->config['github_url']);
+			}
+			if (! array_key_exists('raw_url')){
+				// the github raw url of your github repo
+				$this->config['raw_url'] = str_replace("github.com", "raw.github.com", $this->config['github_url']) . '/' .$this->config['branch']; 
+			}
+			if (! array_key_exists('zip_url')){
+				// the zip url of the github repo
+				$this->config['zip_url'] = $this->config['github_url'].'/zipball/'.$this->config['branch']; 
+			}
+		}
 
 		// if the minimum config isn't set, issue a warning and bail
 		if ( ! $this->has_minimum_config() ) {


### PR DESCRIPTION
this Pull request allows a slimmer $config array, by building the api_url, raw_url and zip_url URLs in the constructor since the are usually the same. 

So instead of this:

``` php
 $config = array(
        'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
        'proper_folder_name' => 'plugin-name', // this is the name of the folder your plugin lives in
        'api_url' => 'https://api.github.com/repos/username/repository-name', // the github API url of your github repo
        'raw_url' => 'https://raw.github.com/username/repository-name/master', // the github raw url of your github repo
        'github_url' => 'https://github.com/username/repository-name', // the github url of your github repo
        'zip_url' => 'https://github.com/username/repository-name/zipball/master', // the zip url of the github repo
        'sslverify' => true // wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
        'requires' => '3.0', // which version of WordPress does your plugin require?
        'tested' => '3.3', // which version of WordPress is your plugin tested up to?
        'readme' => 'README.md', // which file to use as the readme for the version number
        'access_token' => '', // Access private repositories by authorizing under Appearance > Github Updates when this example plugin is installed
    );
```

``` php
$config = array(
        'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
        'proper_folder_name' => 'plugin-name', // this is the name of the folder your plugin lives in
        'github_url' => 'https://github.com/username/repository-name', // the github url of your github repo
        'requires' => '3.0', // which version of WordPress does your plugin require?
        'tested' => '3.3', // which version of WordPress is your plugin tested up to?
        'readme' => 'README.md', // which file to use as the readme for the version number
      );
```

Most of this was already possible but just not for these parameters, so i turned them into optional parameters to keep backwards capability and allow customization. 
Also   i added a new parameter `branch` which defaults to master but it's nice to have the ability to change that so the zip file downloaded is of another branch. 
