### PR TITLE
Changes/Fix to 'forcing update'

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -125,11 +125,10 @@ class WP_GitHub_Updater {
 	/**
 	 * Check wether or not the transients need to be overruled and API needs to be called for every single page load
 	 *
-	 * @access private
 	 * @return bool overrule or not
 	 */
-	private function overrule_transients() {
-		return ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_GITHUB_FORCE_UPDATE' ) || WP_GITHUB_FORCE_UPDATE );
+	public function overrule_transients() {
+		return ( defined( 'WP_GITHUB_FORCE_UPDATE' ) && WP_GITHUB_FORCE_UPDATE );
 	}
 
 


### PR DESCRIPTION
- makes the overrule_transients() method public
- removes from condition `WP_DEBUG` constant (class is intended for development use, and constant very often defined)
