### PR TITLE
WP_ERROR Fix

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -225,10 +225,10 @@ class WP_GitHub_Updater {
 			if ( is_wp_error( $raw_response ) )
 				$version = false;
 
-			if (is_array($raw_response))
-				preg_match( '#^\s*Version\:\s*(.*)$#im', $raw_response['body'], $matches );
-			else
-				preg_match( '#^\s*Version\:\s*(.*)$#im', $raw_response, $matches );
+			if (is_array($raw_response)) {
+				if (!empty($raw_response['body']))
+					preg_match( '#^\s*Version\:\s*(.*)$#im', $raw_response['body'], $matches );
+			}
 
 			if ( empty( $matches[1] ) )
 				$version = false;


### PR DESCRIPTION
This script occasionally breaks the plugin when trying to activate/update and receiving the $raw_response object as a non-array or nil object. This simple condition fixes it by detecting whether the response exists and is an array before outputting the response.
