### PR TITLE
Updated to use the new zip file url format.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -50,7 +50,7 @@ function github_plugin_updater_test_init() {
 			'api_url' => 'https://api.github.com/repos/jkudish/WordPress-GitHub-Plugin-Updater',
 			'raw_url' => 'https://raw.github.com/jkudish/WordPress-GitHub-Plugin-Updater/master',
 			'github_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater',
-			'zip_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/zipball/master',
+			'zip_url' => 'https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/archive/master.zip',
 			'sslverify' => true,
 			'requires' => '3.0',
 			'tested' => '3.3',


### PR DESCRIPTION
With the new UI update Github has changed the urls for fetching packages. The old format now only works with the master branch, so we should update the example url to what will work with any branch.
