### PR TITLE
When searching under Plugins > Add New this warning shows up 

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -377,7 +377,7 @@ class WP_GitHub_Updater {
 	public function get_plugin_info( $false, $action, $response ) {
 
 		// Check if this call API is for the right plugin
-		if ( $response->slug != $this->config['slug'] )
+		if ( !isset( $response->slug ) || $response->slug != $this->config['slug'] )
 			return false;
 
 		$response->slug = $this->config['slug'];


### PR DESCRIPTION
`Notice: Undefined property: stdClass::$slug in /doc_root/wp-content/plugins/github-updater/updater.php on line 379` To fix this we just need to make sure the slug property exists before checking !=
