### PR TITLE
Formatting and typo fixes in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage instructions
 			'raw_url' => 'https://raw.github.com/username/repository-name/master', // the GitHub raw url of your GitHub repo
 			'github_url' => 'https://github.com/username/repository-name', // the GitHub url of your GitHub repo
 			'zip_url' => 'https://github.com/username/repository-name/zipball/master', // the zip url of the GitHub repo
-			'sslverify' => true // wether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
+			'sslverify' => true // whether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
 			'requires' => '3.0', // which version of WordPress does your plugin require?
 			'tested' => '3.3', // which version of WordPress is your plugin tested up to?
 			'readme' => 'README.md', // which file to use as the readme for the version number


### PR DESCRIPTION
Most significant is the correct capitalization of GitHub. I’ll send in another PR in just a moment which fixes the capitalization in the plugin as well.
