### PR TITLE
Version detection improvements

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -212,7 +212,7 @@ class WP_GitHub_Updater {
 	 * @return int $version the version number
 	 */
 	public function get_new_version() {
-		$version = get_site_transient( $this->config['slug'].'_new_version' );
+		$version = get_site_transient( md5($this->config['slug']).'_new_version' );
 
 		if ( $this->overrule_transients() || ( !isset( $version ) || !$version || '' == $version ) ) {
 
@@ -250,7 +250,7 @@ class WP_GitHub_Updater {
 
 			// refresh every 6 hours
 			if ( false !== $version )
-				set_site_transient( $this->config['slug'].'_new_version', $version, 60*60*6 );
+				set_site_transient( md5($this->config['slug']).'_new_version', $version, 60*60*6 );
 		}
 
 		return $version;
@@ -287,7 +287,7 @@ class WP_GitHub_Updater {
 		if ( isset( $this->github_data ) && ! empty( $this->github_data ) ) {
 			$github_data = $this->github_data;
 		} else {
-			$github_data = get_site_transient( $this->config['slug'].'_github_data' );
+			$github_data = get_site_transient( md5($this->config['slug']).'_github_data' );
 
 			if ( $this->overrule_transients() || ( ! isset( $github_data ) || ! $github_data || '' == $github_data ) ) {
 				$github_data = $this->remote_get( $this->config['api_url'] );
@@ -298,7 +298,7 @@ class WP_GitHub_Updater {
 				$github_data = json_decode( $github_data['body'] );
 
 				// refresh every 6 hours
-				set_site_transient( $this->config['slug'].'_github_data', $github_data, 60*60*6 );
+				set_site_transient( md5($this->config['slug']).'_github_data', $github_data, 60*60*6 );
 			}
 
 			// Store the data in this class instance for future calls


### PR DESCRIPTION
Made the regex a little smarter, so it will read different notations of the version in plugin headers as well.

Closes #62 as well, skip reading the readme file if there is already a version found.
