### PR TITLE
Do not ignore force-check

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -214,7 +214,7 @@ class WP_GitHub_Updater {
 	public function get_new_version() {
 		$version = get_site_transient( md5($this->config['slug']).'_new_version' );
 
-		if ( $this->overrule_transients() || ( !isset( $version ) || !$version || '' == $version ) ) {
+		if ( ( $this->overrule_transients() || ( !isset( $version ) || !$version || '' == $version ) ) || (isset($_GET['force-check']) && $_GET['force-check']==1) ) {
 
 			$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . basename( $this->config['slug'] ) );
 


### PR DESCRIPTION
When user click on "Check Again" button on Update page, the plugin will check updates on plugin