### PR TITLE
PHPCodeSniffer WordPress Coding Standards updates

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -1,11 +1,6 @@
 <?php
-
-// Prevent loading this file directly and/or if the class is already defined
-if ( ! defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists( 'WP_GitHub_Updater' ) )
-	return;
-
 /**
- *
+ * WP Github Updater
  *
  * @version 1.6
  * @author Joachim Kudish <info@jkudish.com>
@@ -31,6 +26,15 @@ if ( ! defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
+
+/* Prevent loading this file directly and/or if the class is already defined */
+if ( ! defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists( 'WP_GitHub_Updater' ) ) {
+	return;
+}
+
+/**
+ * Create class
+ */
 class WP_GitHub_Updater {
 
 	/**
@@ -39,18 +43,24 @@ class WP_GitHub_Updater {
 	const VERSION = 1.6;
 
 	/**
+	 * Config variable
+	 *
 	 * @var $config the config for the updater
 	 * @access public
 	 */
 	var $config;
 
 	/**
+	 * Missing config variable
+	 *
 	 * @var $missing_config any config that is missing from the initialization of this instance
 	 * @access public
 	 */
 	var $missing_config;
 
 	/**
+	 * Github data storage
+	 *
 	 * @var $github_data temporiraly store the data fetched from GitHub, allows us to only load the data once per class instance
 	 * @access private
 	 */
@@ -61,7 +71,7 @@ class WP_GitHub_Updater {
 	 * Class Constructor
 	 *
 	 * @since 1.0
-	 * @param array $config the configuration required for the updater to work
+	 * @param array $config the configuration required for the updater to work.
 	 * @see has_minimum_config()
 	 * @return void
 	 */
@@ -76,7 +86,7 @@ class WP_GitHub_Updater {
 
 		$this->config = wp_parse_args( $config, $defaults );
 
-		// if the minimum config isn't set, issue a warning and bail
+		/* If the minimum config isn't set, issue a warning and bail */
 		if ( ! $this->has_minimum_config() ) {
 			$message = 'The GitHub Updater was initialized without the minimum required configuration, please check the config in your plugin. The following params are missing: ';
 			$message .= implode( ',', $this->missing_config );
@@ -88,17 +98,22 @@ class WP_GitHub_Updater {
 
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ) );
 
-		// Hook into the plugin details screen
+		/* Hook into the plugin details screen */
 		add_filter( 'plugins_api', array( $this, 'get_plugin_info' ), 10, 3 );
 		add_filter( 'upgrader_post_install', array( $this, 'upgrader_post_install' ), 10, 3 );
 
-		// set timeout
+		/* set timeout */
 		add_filter( 'http_request_timeout', array( $this, 'http_request_timeout' ) );
 
-		// set sslverify for zip download
+		/* set sslverify for zip download */
 		add_filter( 'http_request_args', array( $this, 'http_request_sslverify' ), 10, 2 );
 	}
 
+	/**
+	 * Check minimum config
+	 *
+	 * @since 1.0
+	 */
 	public function has_minimum_config() {
 
 		$this->missing_config = array();
@@ -114,8 +129,9 @@ class WP_GitHub_Updater {
 		);
 
 		foreach ( $required_config_params as $required_param ) {
-			if ( empty( $this->config[$required_param] ) )
+			if ( empty( $this->config[ $required_param ] ) ) {
 				$this->missing_config[] = $required_param;
+			}
 		}
 
 		return ( empty( $this->missing_config ) );
@@ -139,10 +155,10 @@ class WP_GitHub_Updater {
 	 * @return void
 	 */
 	public function set_defaults() {
-		if ( !empty( $this->config['access_token'] ) ) {
+		if ( ! empty( $this->config['access_token'] ) ) {
 
 			// See Downloading a zipball (private repo) https://help.github.com/articles/downloading-files-from-the-command-line
-			extract( parse_url( $this->config['zip_url'] ) ); // $scheme, $host, $path
+			extract( parse_url( $this->config['zip_url'] ) ); /* $scheme, $host, $path */
 
 			$zip_url = $scheme . '://api.github.com/repos' . $path;
 			$zip_url = add_query_arg( array( 'access_token' => $this->config['access_token'] ), $zip_url );
@@ -150,34 +166,40 @@ class WP_GitHub_Updater {
 			$this->config['zip_url'] = $zip_url;
 		}
 
-
-		if ( ! isset( $this->config['new_version'] ) )
+		if ( ! isset( $this->config['new_version'] ) ) {
 			$this->config['new_version'] = $this->get_new_version();
+		}
 
-		if ( ! isset( $this->config['last_updated'] ) )
+		if ( ! isset( $this->config['last_updated'] ) ) {
 			$this->config['last_updated'] = $this->get_date();
+		}
 
-		if ( ! isset( $this->config['description'] ) )
+		if ( ! isset( $this->config['description'] ) ) {
 			$this->config['description'] = $this->get_description();
+		}
 
 		$plugin_data = $this->get_plugin_data();
-		if ( ! isset( $this->config['plugin_name'] ) )
+		if ( ! isset( $this->config['plugin_name'] ) ) {
 			$this->config['plugin_name'] = $plugin_data['Name'];
+		}
 
-		if ( ! isset( $this->config['version'] ) )
+		if ( ! isset( $this->config['version'] ) ) {
 			$this->config['version'] = $plugin_data['Version'];
+		}
 
-		if ( ! isset( $this->config['author'] ) )
+		if ( ! isset( $this->config['author'] ) ) {
 			$this->config['author'] = $plugin_data['Author'];
+		}
 
-		if ( ! isset( $this->config['homepage'] ) )
+		if ( ! isset( $this->config['homepage'] ) ) {
 			$this->config['homepage'] = $plugin_data['PluginURI'];
+		}
 
-		if ( ! isset( $this->config['readme'] ) )
+		if ( ! isset( $this->config['readme'] ) ) {
 			$this->config['readme'] = 'README.md';
+		}
 
 	}
-
 
 	/**
 	 * Callback fn for the http_request_timeout filter
@@ -198,8 +220,9 @@ class WP_GitHub_Updater {
 	 * @return mixed
 	 */
 	public function http_request_sslverify( $args, $url ) {
-		if ( $this->config[ 'zip_url' ] == $url )
-			$args[ 'sslverify' ] = $this->config[ 'sslverify' ];
+		if ( $this->config['zip_url'] == $url ) {
+			$args['sslverify'] = $this->config['sslverify'];
+		}
 
 		return $args;
 	}
@@ -212,45 +235,53 @@ class WP_GitHub_Updater {
 	 * @return int $version the version number
 	 */
 	public function get_new_version() {
-		$version = get_site_transient( md5($this->config['slug']).'_new_version' );
+		$version = get_site_transient( md5( $this->config['slug'] ).'_new_version' );
 
-		if ( $this->overrule_transients() || ( !isset( $version ) || !$version || '' == $version ) ) {
+		if ( $this->overrule_transients() || ( ! isset( $version ) || ! $version || '' == $version ) ) {
 
 			$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . basename( $this->config['slug'] ) );
 
-			if ( is_wp_error( $raw_response ) )
+			if ( is_wp_error( $raw_response ) ) {
 				$version = false;
-
-			if (is_array($raw_response)) {
-				if (!empty($raw_response['body']))
-					preg_match( '/.*Version\:\s*(.*)$/mi', $raw_response['body'], $matches );
 			}
 
-			if ( empty( $matches[1] ) )
-				$version = false;
-			else
-				$version = $matches[1];
+			if ( is_array( $raw_response ) ) {
+				if ( ! empty( $raw_response['body'] ) ) {
+					preg_match( '/.*Version\:\s*(.*)$/mi', $raw_response['body'], $matches );
+				}
+			}
 
-			// back compat for older readme version handling
-			// only done when there is no version found in file name
+			if ( empty( $matches[1] ) ) {
+				$version = false;
+			} else {
+				$version = $matches[1];
+			}
+
+			/**
+			 * Back compat for older readme version handling
+			 * only done when there is no version found in file name
+			 */
 			if ( false === $version ) {
 				$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . $this->config['readme'] );
 
-				if ( is_wp_error( $raw_response ) )
+				if ( is_wp_error( $raw_response ) ) {
 					return $version;
+				}
 
 				preg_match( '#^\s*`*~Current Version\:\s*([^~]*)~#im', $raw_response['body'], $__version );
 
 				if ( isset( $__version[1] ) ) {
 					$version_readme = $__version[1];
-					if ( -1 == version_compare( $version, $version_readme ) )
+					if ( -1 == version_compare( $version, $version_readme ) ) {
 						$version = $version_readme;
+					}
 				}
 			}
 
-			// refresh every 6 hours
-			if ( false !== $version )
-				set_site_transient( md5($this->config['slug']).'_new_version', $version, 60*60*6 );
+			/* refresh every 6 hours */
+			if ( false !== $version ) {
+				set_site_transient( md5( $this->config['slug'] ).'_new_version', $version, 60 * 60 * 6 );
+			}
 		}
 
 		return $version;
@@ -266,11 +297,12 @@ class WP_GitHub_Updater {
 	 * @return mixed
 	 */
 	public function remote_get( $query ) {
-		if ( ! empty( $this->config['access_token'] ) )
+		if ( ! empty( $this->config['access_token'] ) ) {
 			$query = add_query_arg( array( 'access_token' => $this->config['access_token'] ), $query );
+		}
 
 		$raw_response = wp_remote_get( $query, array(
-			'sslverify' => $this->config['sslverify']
+			'sslverify' => $this->config['sslverify'],
 		) );
 
 		return $raw_response;
@@ -287,21 +319,22 @@ class WP_GitHub_Updater {
 		if ( isset( $this->github_data ) && ! empty( $this->github_data ) ) {
 			$github_data = $this->github_data;
 		} else {
-			$github_data = get_site_transient( md5($this->config['slug']).'_github_data' );
+			$github_data = get_site_transient( md5( $this->config['slug'] ).'_github_data' );
 
 			if ( $this->overrule_transients() || ( ! isset( $github_data ) || ! $github_data || '' == $github_data ) ) {
 				$github_data = $this->remote_get( $this->config['api_url'] );
 
-				if ( is_wp_error( $github_data ) )
+				if ( is_wp_error( $github_data ) ) {
 					return false;
+				}
 
 				$github_data = json_decode( $github_data['body'] );
 
-				// refresh every 6 hours
-				set_site_transient( md5($this->config['slug']).'_github_data', $github_data, 60*60*6 );
+				/* Refresh every 6 hours */
+				set_site_transient( md5( $this->config['slug'] ).'_github_data', $github_data, 60 * 60 * 6 );
 			}
 
-			// Store the data in this class instance for future calls
+			/* Store the data in this class instance for future calls */
 			$this->github_data = $github_data;
 		}
 
@@ -317,7 +350,7 @@ class WP_GitHub_Updater {
 	 */
 	public function get_date() {
 		$_date = $this->get_github_data();
-		return ( !empty( $_date->updated_at ) ) ? date( 'Y-m-d', strtotime( $_date->updated_at ) ) : false;
+		return ( ! empty( $_date->updated_at ) ) ? date( 'Y-m-d', strtotime( $_date->updated_at ) ) : false;
 	}
 
 
@@ -329,7 +362,7 @@ class WP_GitHub_Updater {
 	 */
 	public function get_description() {
 		$_description = $this->get_github_data();
-		return ( !empty( $_description->description ) ) ? $_description->description : false;
+		return ( ! empty( $_description->description ) ) ? $_description->description : false;
 	}
 
 
@@ -350,17 +383,20 @@ class WP_GitHub_Updater {
 	 * Hook into the plugin update check and connect to GitHub
 	 *
 	 * @since 1.0
-	 * @param object  $transient the plugin data transient
+	 * @param object $transient the plugin data transient
 	 * @return object $transient updated plugin data transient
 	 */
 	public function api_check( $transient ) {
 
-		// Check if the transient contains the 'checked' information
-		// If not, just return its value without hacking it
-		if ( empty( $transient->checked ) )
+		/**
+		 * Check if the transient contains the 'checked' information
+		 * If not, just return its value without hacking it
+		 */
+		if ( empty( $transient->checked ) ) {
 			return $transient;
+		}
 
-		// check the version and decide if it's new
+		/* check the version and decide if it's new */
 		$update = version_compare( $this->config['new_version'], $this->config['version'] );
 
 		if ( 1 === $update ) {
@@ -370,29 +406,30 @@ class WP_GitHub_Updater {
 			$response->url = add_query_arg( array( 'access_token' => $this->config['access_token'] ), $this->config['github_url'] );
 			$response->package = $this->config['zip_url'];
 
-			// If response is false, don't alter the transient
-			if ( false !== $response )
+			/* If response is false, don't alter the transient */
+			if ( false !== $response ) {
 				$transient->response[ $this->config['slug'] ] = $response;
+			}
 		}
 
 		return $transient;
 	}
 
-
 	/**
 	 * Get Plugin info
 	 *
 	 * @since 1.0
-	 * @param bool    $false  always false
-	 * @param string  $action the API function being performed
-	 * @param object  $args   plugin arguments
-	 * @return object $response the plugin info
+	 * @param bool      $false  always false
+	 * @param string    $action the API function being performed
+	 * @param object    args   plugin arguments
+	 * @return object   $response the plugin info
 	 */
 	public function get_plugin_info( $false, $action, $response ) {
 
-		// Check if this call API is for the right plugin
-		if ( !isset( $response->slug ) || $response->slug != $this->config['slug'] )
+		/* Check if this call API is for the right plugin */
+		if ( ! isset( $response->slug ) || $response->slug != $this->config['slug'] ) {
 			return false;
+		}
 
 		$response->slug = $this->config['slug'];
 		$response->plugin_name  = $this->config['plugin_name'];
@@ -418,19 +455,19 @@ class WP_GitHub_Updater {
 	 * @param boolean $true       always true
 	 * @param mixed   $hook_extra not used
 	 * @param array   $result     the result of the move
-	 * @return array $result the result of the move
+	 * @return array  $result the result of the move
 	 */
 	public function upgrader_post_install( $true, $hook_extra, $result ) {
 
 		global $wp_filesystem;
 
-		// Move & Activate
+		/* Move & Activate */
 		$proper_destination = WP_PLUGIN_DIR.'/'.$this->config['proper_folder_name'];
 		$wp_filesystem->move( $result['destination'], $proper_destination );
 		$result['destination'] = $proper_destination;
 		$activate = activate_plugin( WP_PLUGIN_DIR.'/'.$this->config['slug'] );
 
-		// Output the update message
+		/* Output the update message */
 		$fail  = __( 'The plugin has been updated, but could not be reactivated. Please reactivate it manually.', 'github_plugin_updater' );
 		$success = __( 'Plugin reactivated successfully.', 'github_plugin_updater' );
 		echo is_wp_error( $activate ) ? $fail : $success;


### PR DESCRIPTION
The original scan with [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) brought up 111 errors, effecting 72 lines and this update brings it down to 20 errors, effecting 16 lines.