### PR TITLE
Add filter for checking if update is needed

### DIFF
--- a/updater.php
+++ b/updater.php
@@ -362,6 +362,7 @@ class WP_GitHub_Updater {
 
 		// check the version and decide if it's new
 		$update = version_compare( $this->config['new_version'], $this->config['version'] );
+		$update = apply_filters( 'wp_github_update_check', $update, $this->config['new_version'], $this->config['version'] );
 
 		if ( 1 === $update ) {
 			$response = new stdClass;


### PR DESCRIPTION
Adds a filter `wp_github_update_check` to the API check to see if there is a new update available.

For example, a project may want to modify the api check update to only allow an update if it's outside of a [SemVer Major release (breaking change)](https://semver.org/#summary). This filter allows them to do so without actually modifying the `updater.php` class.

Related issue: #92 